### PR TITLE
Add time tracker layout and interactive balloons

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="id">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -11,42 +11,81 @@
   <div class="ballistic-wrapper">
     <header>
       <h1>🎯 Happy Ballistic Birthday!</h1>
-      <p id="typing"></p>
+      <p id="typing" aria-live="polite"></p>
     </header>
 
-    <section id="quiz" class="quiz-card">
-      <p>🕵️ Sebelum lanjut, jawab teka-teki ini:</p>
-      <p><strong>"Aku bulat, ada lilin di atas, aku manis. Apakah aku?"</strong></p>
-      <div class="quiz-inputs">
-        <input type="text" id="answer" placeholder="Tulis jawabannya...">
-        <button id="quizButton" onclick="checkAnswer()">Jawab</button>
+    <section class="time-card" aria-labelledby="timeHeading">
+      <div class="time-card__header">
+        <h2 id="timeHeading">Waktu Berjalan Sejak 4 Oktober 1974</h2>
+        <p>Kita rayakan setiap detik berharga yang telah menemani perjalananmu.</p>
+      </div>
+      <div class="time-grid" role="presentation">
+        <article class="time-unit">
+          <span class="time-number" id="years">0</span>
+          <span class="time-label">Tahun</span>
+        </article>
+        <article class="time-unit">
+          <span class="time-number" id="months">0</span>
+          <span class="time-label">Bulan</span>
+        </article>
+        <article class="time-unit">
+          <span class="time-number" id="days">0</span>
+          <span class="time-label">Hari</span>
+        </article>
+        <article class="time-unit">
+          <span class="time-number" id="hours">0</span>
+          <span class="time-label">Jam</span>
+        </article>
+        <article class="time-unit">
+          <span class="time-number" id="minutes">0</span>
+          <span class="time-label">Menit</span>
+        </article>
+        <article class="time-unit">
+          <span class="time-number" id="seconds">0</span>
+          <span class="time-label">Detik</span>
+        </article>
       </div>
     </section>
 
-    <section id="celebration" class="celebration" aria-live="polite">
-      <div id="secretMessage">🎉 Selamat Ulang Tahun! Semoga panjang umur, sehat selalu, dan bahagia! 🎁</div>
+    <section class="celebration" aria-live="polite">
+      <p class="celebration__message">🎉 Selamat Ulang Tahun! Semoga segala doa, asa, dan rencana yang kamu simpan rapi perlahan satu per satu jadi kenyataan.</p>
+      <p class="celebration__note">Gulir terus ke bawah, karena cerita indahmu masih panjang dan siap diisi dengan foto serta kenangan baru.</p>
+    </section>
 
-      <div class="photo-slider" aria-label="Galeri foto kenangan">
-        <button class="slider-nav prev" aria-label="Foto sebelumnya">‹</button>
+    <section class="photo-section" aria-labelledby="galleryHeading">
+      <div class="photo-section__intro">
+        <h2 id="galleryHeading">Galeri Kenangan (Placeholder)</h2>
+        <p>Tempat foto-foto spesialmu akan tinggal. Untuk sekarang, geser ke kanan atau kiri untuk melihat placeholder-nya.</p>
+      </div>
+      <div class="photo-slider" aria-label="Galeri foto yang dapat digeser">
+        <button class="slider-nav prev" aria-label="Foto sebelumnya" type="button">‹</button>
         <div class="slides-window">
           <div class="slides">
             <figure class="slide">
-              <img src="https://images.unsplash.com/photo-1528716321680-815a8cdb8cbe?auto=format&fit=crop&w=900&q=80" alt="Balon warna-warni dengan nuansa pesta">
-              <figcaption>Kenangan seru di pesta tahun lalu.</figcaption>
+              <div class="photo-placeholder">Foto pertama akan tampil di sini.</div>
+              <figcaption>Siapkan cerita terbaik untuk momen istimewa ini.</figcaption>
             </figure>
             <figure class="slide">
-              <img src="https://images.unsplash.com/photo-1529653762956-b0a27278529c?auto=format&fit=crop&w=900&q=80" alt="Kue ulang tahun dengan dekorasi mewah">
-              <figcaption>Kue spesial penuh makna.</figcaption>
+              <div class="photo-placeholder">Tempat untuk potret kebersamaan.</div>
+              <figcaption>Tinggalkan jejak kebersamaan yang hangat.</figcaption>
             </figure>
             <figure class="slide">
-              <img src="https://images.unsplash.com/photo-1486427944299-d1955d23e34d?auto=format&fit=crop&w=900&q=80" alt="Sahabat tertawa bersama di pesta">
-              <figcaption>Momen tawa bersama sahabat.</figcaption>
+              <div class="photo-placeholder">Kenangan spesial menyusul segera.</div>
+              <figcaption>Kenangan baru siap kamu simpan di sini.</figcaption>
+            </figure>
+            <figure class="slide">
+              <div class="photo-placeholder">Ruangan kosong untuk kejutan.</div>
+              <figcaption>Mungkin foto kejutan dari sahabat terdekatmu?</figcaption>
             </figure>
           </div>
         </div>
-        <button class="slider-nav next" aria-label="Foto berikutnya">›</button>
+        <button class="slider-nav next" aria-label="Foto berikutnya" type="button">›</button>
       </div>
     </section>
+
+    <footer class="closing-note">
+      <p>Terima kasih sudah menjadi bagian dari perjalanan panjang nan bermakna ini. Mari lanjutkan perayaannya dengan senyum lebar dan hati ringan.</p>
+    </footer>
   </div>
 
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,83 +1,96 @@
-// ✨ Efek typing bertema balistik
-const text = "Klik sekali untuk memulai misi ulang tahun 🎯";
+const typingText = "Setiap detikmu begitu berarti — mari rayakan perjalanan panjang ini.";
+const baseDate = new Date(1974, 9, 4, 0, 0, 0);
 let typingIndex = 0;
-let typingStarted = false;
 
 function typingEffect() {
-  if (typingStarted) return;
-  typingStarted = true;
-
   const typingContainer = document.getElementById("typing");
+  if (!typingContainer) return;
+
   function typeNext() {
-    if (typingIndex < text.length) {
-      typingContainer.innerHTML += text.charAt(typingIndex);
-      typingIndex++;
+    if (typingIndex < typingText.length) {
+      typingContainer.innerHTML += typingText.charAt(typingIndex);
+      typingIndex += 1;
       setTimeout(typeNext, 70);
-    } else {
-      document.getElementById("quiz").style.display = "block";
     }
   }
 
   typeNext();
 }
 
-document.body.addEventListener("click", typingEffect, { once: true });
+function updateElapsedTime() {
+  const now = new Date();
+  if (now < baseDate) return;
 
-// 🕵️ Quiz sederhana
-function checkAnswer() {
-  const ans = document.getElementById("answer").value.toLowerCase();
-  if (ans.includes("kue") || ans.includes("cake")) {
-    const quiz = document.getElementById("quiz");
-    quiz.style.display = "none";
-    const celebration = document.getElementById("celebration");
-    celebration.style.display = "flex";
-    const secretMessage = document.getElementById("secretMessage");
-    secretMessage.style.display = "block";
-    triggerLaunchSequence();
-    setTimeout(updateSlidePosition, 20);
-  } else {
-    alert("Hehe coba lagi, pikirkan ulang 🎂");
+  let years = now.getFullYear() - baseDate.getFullYear();
+  let months = now.getMonth() - baseDate.getMonth();
+  let days = now.getDate() - baseDate.getDate();
+
+  if (days < 0) {
+    months -= 1;
+    const prevMonthLength = new Date(now.getFullYear(), now.getMonth(), 0).getDate();
+    days += prevMonthLength;
   }
-}
 
-// 🚀 Peluncuran roket perayaan
-function triggerLaunchSequence() {
-  for (let i = 0; i < 16; i++) {
-    const rocket = document.createElement("div");
-    rocket.classList.add("balloon");
-    rocket.textContent = "🚀";
-    rocket.style.left = Math.random() * 100 + "vw";
-    rocket.style.animationDuration = 4 + Math.random() * 3 + "s";
-    document.body.appendChild(rocket);
-    setTimeout(() => rocket.remove(), 7000);
+  if (months < 0) {
+    years -= 1;
+    months += 12;
   }
+
+  const anchor = new Date(baseDate);
+  anchor.setFullYear(baseDate.getFullYear() + years);
+  anchor.setMonth(baseDate.getMonth() + months);
+  anchor.setDate(baseDate.getDate() + days);
+
+  let diffMs = now - anchor;
+  const hours = Math.floor(diffMs / (1000 * 60 * 60));
+  diffMs -= hours * 60 * 60 * 1000;
+  const minutes = Math.floor(diffMs / (1000 * 60));
+  diffMs -= minutes * 60 * 1000;
+  const seconds = Math.floor(diffMs / 1000);
+
+  const map = {
+    years,
+    months,
+    days,
+    hours,
+    minutes,
+    seconds
+  };
+
+  Object.entries(map).forEach(([key, value]) => {
+    const target = document.getElementById(key);
+    if (target) {
+      target.textContent = value.toLocaleString("id-ID");
+    }
+  });
 }
 
-// 🎞️ Slider foto
-const slidesWindow = document.querySelector(".slides-window");
-const slidesContainer = document.querySelector(".slides");
-const slides = document.querySelectorAll(".slide");
-const prevButton = document.querySelector(".slider-nav.prev");
-const nextButton = document.querySelector(".slider-nav.next");
-let currentSlide = 0;
+function initSlider() {
+  const slidesWindow = document.querySelector(".slides-window");
+  const slidesContainer = document.querySelector(".slides");
+  const slides = document.querySelectorAll(".slide");
+  const prevButton = document.querySelector(".slider-nav.prev");
+  const nextButton = document.querySelector(".slider-nav.next");
+  let currentSlide = 0;
 
-function updateSlidePosition() {
-  if (!slidesContainer || !slides.length) return;
-  const slideWidth = slidesWindow?.getBoundingClientRect().width || 0;
-  slidesContainer.style.transform = `translateX(-${currentSlide * slideWidth}px)`;
-}
+  function updateSlidePosition() {
+    if (!slidesContainer || !slidesWindow) return;
+    const slideWidth = slidesWindow.getBoundingClientRect().width;
+    slidesContainer.style.transform = `translateX(-${currentSlide * slideWidth}px)`;
+  }
 
-function goToSlide(index) {
-  if (!slides.length) return;
-  currentSlide = (index + slides.length) % slides.length;
+  function goToSlide(index) {
+    if (!slides.length) return;
+    currentSlide = (index + slides.length) % slides.length;
+    updateSlidePosition();
+  }
+
+  prevButton?.addEventListener("click", () => goToSlide(currentSlide - 1));
+  nextButton?.addEventListener("click", () => goToSlide(currentSlide + 1));
+  window.addEventListener("resize", updateSlidePosition);
   updateSlidePosition();
 }
 
-prevButton?.addEventListener("click", () => goToSlide(currentSlide - 1));
-nextButton?.addEventListener("click", () => goToSlide(currentSlide + 1));
-window.addEventListener("resize", updateSlidePosition);
-
-// ✨ Sparkle mengikuti kursor
 function createSparkle(x, y) {
   const sparkle = document.createElement("span");
   sparkle.className = "sparkle";
@@ -87,12 +100,79 @@ function createSparkle(x, y) {
   setTimeout(() => sparkle.remove(), 600);
 }
 
-document.addEventListener("mousemove", (event) => {
-  if (!typingStarted) return;
-  createSparkle(event.clientX, event.clientY);
-});
+function handlePointerTrail() {
+  document.addEventListener("mousemove", (event) => {
+    createSparkle(event.clientX, event.clientY);
+  });
+}
 
-// 🎆 Fireworks
+function createBurst(x, y, color) {
+  const burst = document.createElement("div");
+  burst.className = "burst";
+  burst.style.left = `${x}px`;
+  burst.style.top = `${y}px`;
+
+  const particles = 8;
+  for (let i = 0; i < particles; i += 1) {
+    const shard = document.createElement("span");
+    const angle = (360 / particles) * i;
+    shard.style.transform = `translate(-50%, -50%) rotate(${angle}deg)`;
+    shard.style.background = color;
+    burst.appendChild(shard);
+  }
+
+  document.body.appendChild(burst);
+  setTimeout(() => burst.remove(), 450);
+}
+
+function spawnBalloon() {
+  const balloon = document.createElement("div");
+  balloon.className = "balloon";
+
+  const hue = Math.floor(Math.random() * 360);
+  const size = 70 + Math.random() * 50;
+  const duration = 12 + Math.random() * 8;
+  const leftPosition = Math.random() * 100;
+
+  balloon.style.width = `${size}px`;
+  balloon.style.height = `${size * 1.35}px`;
+  balloon.style.left = `calc(${leftPosition}vw)`;
+  balloon.style.animationDuration = `${duration}s`;
+  balloon.style.background = `radial-gradient(circle at 30% 25%, rgba(255,255,255,0.7), hsla(${hue}, 90%, 65%, 0.95) 55%, hsla(${hue}, 90%, 55%, 0.95) 100%)`;
+
+  document.body.appendChild(balloon);
+
+  const removeTimeout = setTimeout(() => {
+    balloon.remove();
+  }, (duration + 2) * 1000);
+
+  balloon.addEventListener("click", (event) => {
+    event.stopPropagation();
+    const rect = balloon.getBoundingClientRect();
+    const x = rect.left + rect.width / 2;
+    const y = rect.top + rect.height / 2;
+    createBurst(x, y, `hsla(${hue}, 95%, 70%, 1)`);
+    balloon.classList.add("popped");
+    clearTimeout(removeTimeout);
+    setTimeout(() => balloon.remove(), 320);
+  });
+}
+
+function startBalloons() {
+  const minInterval = 1600;
+  const maxInterval = 3200;
+
+  function scheduleNext() {
+    const delay = Math.random() * (maxInterval - minInterval) + minInterval;
+    setTimeout(() => {
+      spawnBalloon();
+      scheduleNext();
+    }, delay);
+  }
+
+  scheduleNext();
+}
+
 const canvas = document.getElementById("confetti");
 const ctx = canvas.getContext("2d");
 let confettiPieces = [];
@@ -103,9 +183,6 @@ function setupCanvas() {
   canvas.height = window.innerHeight;
 }
 
-setupCanvas();
-window.addEventListener("resize", setupCanvas);
-
 function createConfetti() {
   confettiPieces = Array.from({ length: 90 }, () => ({
     x: Math.random() * canvas.width,
@@ -115,8 +192,6 @@ function createConfetti() {
     color: `hsl(${Math.random() * 360}, 90%, 60%)`
   }));
 }
-
-createConfetti();
 
 function drawConfetti() {
   confettiPieces.forEach((piece) => {
@@ -152,7 +227,8 @@ function createFirework(x, y) {
 }
 
 document.addEventListener("click", (event) => {
-  if (event.target.closest(".quiz-card, .slider-nav, input, button")) return;
+  if (event.target.closest("button, .slider-nav, .slides-window, .photo-placeholder")) return;
+  if (event.target.classList.contains("balloon")) return;
   createFirework(event.clientX, event.clientY);
 });
 
@@ -189,4 +265,19 @@ function animate() {
   requestAnimationFrame(animate);
 }
 
-animate();
+window.addEventListener("resize", () => {
+  setupCanvas();
+  createConfetti();
+});
+
+window.addEventListener("DOMContentLoaded", () => {
+  typingEffect();
+  updateElapsedTime();
+  setInterval(updateElapsedTime, 1000);
+  initSlider();
+  handlePointerTrail();
+  startBalloons();
+  setupCanvas();
+  createConfetti();
+  animate();
+});

--- a/style.css
+++ b/style.css
@@ -16,26 +16,26 @@ body {
   margin: 0;
   font-family: "Orbitron", "Montserrat", system-ui, sans-serif;
   min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  display: block;
   background: var(--bg-gradient);
   color: var(--text-light);
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   position: relative;
-  cursor: crosshair;
+  padding: clamp(3rem, 4vw, 5rem) 0;
 }
 
 body::before {
   content: "";
-  position: absolute;
+  position: fixed;
   inset: 0;
-  background-image: url('https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=60');
+  background-image: url("https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=60");
   background-size: cover;
   background-position: center;
   mix-blend-mode: screen;
   opacity: 0.18;
   pointer-events: none;
+  z-index: -1;
 }
 
 #confetti {
@@ -49,27 +49,28 @@ body::before {
 .ballistic-wrapper {
   position: relative;
   z-index: 1;
-  width: min(900px, 95vw);
-  padding: 3rem;
+  width: min(960px, 92vw);
+  margin: 0 auto;
+  padding: clamp(2.5rem, 5vw, 3.75rem);
   border-radius: 32px;
   background: var(--panel);
   border: 1px solid var(--panel-border);
   box-shadow: var(--shadow);
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(14px);
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: clamp(2rem, 4vw, 3rem);
 }
 
 header {
   text-align: center;
   display: grid;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 h1 {
   margin: 0;
-  font-size: clamp(2.5rem, 5vw, 3.5rem);
+  font-size: clamp(2.5rem, 5vw, 3.75rem);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   text-shadow: 0 0 18px rgba(255, 221, 89, 0.6);
@@ -82,71 +83,75 @@ h1 {
   letter-spacing: 0.15em;
 }
 
-.quiz-card {
-  display: none;
-  padding: 1.75rem;
-  border-radius: 20px;
-  border: 1px solid var(--panel-border);
-  background: rgba(18, 23, 41, 0.85);
-  box-shadow: inset 0 0 20px rgba(255, 204, 0, 0.08);
-  animation: pop 0.6s ease;
+.time-card {
+  padding: clamp(1.75rem, 3vw, 2.5rem);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(10, 15, 29, 0.9);
+  display: grid;
+  gap: 1.75rem;
 }
 
-.quiz-card p {
-  margin: 0 0 0.75rem;
-  line-height: 1.6;
-}
-
-.quiz-inputs {
-  display: flex;
+.time-card__header {
+  display: grid;
   gap: 0.75rem;
-  flex-wrap: wrap;
-  justify-content: center;
 }
 
-.quiz-inputs input {
-  flex: 1 1 220px;
-  padding: 0.75rem 1rem;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(8, 11, 20, 0.9);
-  color: var(--text-light);
+.time-card h2 {
+  margin: 0;
+  font-size: clamp(1.5rem, 3vw, 2.1rem);
 }
 
-.quiz-inputs input::placeholder {
-  color: rgba(255, 255, 255, 0.5);
+.time-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: clamp(1rem, 3vw, 1.5rem);
 }
 
-.quiz-inputs button {
-  padding: 0.75rem 1.75rem;
-  border-radius: 999px;
-  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
-  border: none;
-  color: #05070e;
+.time-unit {
+  display: grid;
+  justify-items: center;
+  gap: 0.35rem;
+  padding: 1rem 0.75rem;
+  border-radius: 20px;
+  background: linear-gradient(160deg, rgba(255, 204, 0, 0.2) 0%, rgba(255, 95, 109, 0.25) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: inset 0 0 18px rgba(255, 204, 0, 0.12);
+}
+
+.time-number {
+  font-size: clamp(1.9rem, 4vw, 2.8rem);
   font-weight: 700;
-  letter-spacing: 0.1em;
+  text-shadow: 0 0 12px rgba(255, 221, 89, 0.4);
+}
+
+.time-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.quiz-inputs button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 28px rgba(255, 204, 0, 0.25);
-}
-
-#secretMessage {
-  display: none;
-  font-size: 1.4rem;
-  margin-bottom: 1.5rem;
-  text-align: center;
-  animation: pop 0.7s ease;
+  color: rgba(255, 255, 255, 0.7);
 }
 
 .celebration {
-  display: none;
-  flex-direction: column;
-  gap: 2rem;
+  display: grid;
+  gap: 1rem;
+  line-height: 1.8;
+  font-size: 1.05rem;
+}
+
+.photo-section {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.photo-section__intro {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.photo-section__intro h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
 }
 
 .photo-slider {
@@ -170,18 +175,22 @@ h1 {
 
 .slide {
   flex: 0 0 100%;
-  max-width: min(600px, 70vw);
+  max-width: min(620px, 72vw);
   display: flex;
   flex-direction: column;
   background: rgba(3, 8, 19, 0.9);
 }
 
-.slide img {
-  width: 100%;
-  height: auto;
-  display: block;
-  aspect-ratio: 3 / 2;
-  object-fit: cover;
+.photo-placeholder {
+  display: grid;
+  place-items: center;
+  height: clamp(240px, 45vw, 360px);
+  background: repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.08) 0px, rgba(255, 255, 255, 0.08) 14px, rgba(255, 255, 255, 0.02) 14px, rgba(255, 255, 255, 0.02) 28px);
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 1.05rem;
+  text-align: center;
+  padding: 1.5rem;
+  letter-spacing: 0.05em;
 }
 
 .slide figcaption {
@@ -194,10 +203,10 @@ h1 {
 }
 
 .slider-nav {
-  width: 48px;
-  height: 48px;
+  width: 52px;
+  height: 52px;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.12);
   border: 1px solid rgba(255, 255, 255, 0.35);
   color: var(--accent);
   font-size: 2rem;
@@ -206,31 +215,99 @@ h1 {
   transition: transform 0.2s ease, background 0.2s ease;
 }
 
-.slider-nav:hover {
-  background: rgba(255, 204, 0, 0.18);
+.slider-nav:hover,
+.slider-nav:focus-visible {
+  background: rgba(255, 204, 0, 0.2);
   transform: scale(1.08);
+}
+
+.slider-nav:focus-visible {
+  outline: 3px solid rgba(255, 204, 0, 0.45);
+  outline-offset: 3px;
+}
+
+.closing-note {
+  text-align: center;
+  font-size: 0.95rem;
+  line-height: 1.8;
+  color: rgba(255, 255, 255, 0.7);
 }
 
 .balloon {
   position: fixed;
-  bottom: -90px;
-  font-size: 2.4rem;
-  animation: launchUp 6s linear infinite;
-  pointer-events: none;
-  z-index: 2;
+  bottom: -160px;
+  width: 80px;
+  height: 110px;
+  border-radius: 60% 60% 60% 60%;
+  transform-origin: center bottom;
+  animation: floatUp linear forwards;
+  pointer-events: auto;
+  z-index: 3;
+  cursor: pointer;
+  filter: drop-shadow(0 8px 12px rgba(0, 0, 0, 0.35));
 }
 
-@keyframes launchUp {
+.balloon::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: -35px;
+  width: 2px;
+  height: 40px;
+  background: rgba(255, 255, 255, 0.35);
+}
+
+.balloon.popped {
+  transform: scale(0.1);
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+@keyframes floatUp {
   0% {
-    transform: translateY(0) scale(0.8);
+    transform: translate(-50%, 0) scale(0.9);
     opacity: 0;
   }
-  20% {
+  10% {
     opacity: 1;
   }
   100% {
-    transform: translateY(-120vh) scale(1.2);
+    transform: translate(-50%, -120vh) scale(1.15);
     opacity: 0;
+  }
+}
+
+.burst {
+  position: fixed;
+  width: 8px;
+  height: 8px;
+  left: 0;
+  top: 0;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+  z-index: 4;
+}
+
+.burst span {
+  position: absolute;
+  width: 6px;
+  height: 16px;
+  border-radius: 50% 50% 50% 50%;
+  background: var(--accent);
+  top: 50%;
+  left: 50%;
+  transform-origin: center -12px;
+  animation: burstFly 0.45s ease-out forwards;
+}
+
+@keyframes burstFly {
+  0% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -300%) scale(0.2);
   }
 }
 
@@ -246,28 +323,38 @@ h1 {
 }
 
 @keyframes sparkleFade {
-  0% { transform: scale(0.2) translate(-50%, -50%); opacity: 1; }
-  50% { transform: scale(1.2) translate(-50%, -50%); opacity: 0.8; }
-  100% { transform: scale(0.1) translate(-50%, -50%); opacity: 0; }
-}
-
-@keyframes pop {
-  0% { transform: scale(0.75); opacity: 0; }
-  100% { transform: scale(1); opacity: 1; }
+  0% {
+    transform: scale(0.2) translate(-50%, -50%);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.2) translate(-50%, -50%);
+    opacity: 0.8;
+  }
+  100% {
+    transform: scale(0.1) translate(-50%, -50%);
+    opacity: 0;
+  }
 }
 
 @media (max-width: 720px) {
-  .ballistic-wrapper {
-    padding: 2.25rem 1.5rem;
+  body {
+    padding: 2.5rem 0;
   }
 
-  .slide {
-    max-width: min(80vw, 500px);
+  .ballistic-wrapper {
+    padding: 2.25rem 1.5rem;
+    gap: 1.75rem;
+  }
+
+  .photo-placeholder {
+    font-size: 0.95rem;
+    padding: 1rem;
   }
 
   .slider-nav {
-    width: 40px;
-    height: 40px;
-    font-size: 1.5rem;
+    width: 44px;
+    height: 44px;
+    font-size: 1.6rem;
   }
 }


### PR DESCRIPTION
## Summary
- replace the quiz card with an always-on elapsed time tracker that counts from 4 October 1974
- add a placeholder photo slider, celebratory copy, and footer to encourage scrolling and future memories
- refresh styles and scripts to support scrolling layout plus randomly spawning balloons that pop on click while keeping celebratory effects

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e02ba8e948832994c9e4f468f383a8