### PR TITLE
Translate birthday page, add timezone clock, and theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="id">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -10,81 +10,88 @@
   <canvas id="confetti"></canvas>
   <div class="ballistic-wrapper">
     <header>
-      <h1>🎯 Happy Ballistic Birthday!</h1>
+      <div class="header-bar">
+        <h1>🎯 Happy Ballistic Birthday!</h1>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false" aria-label="Toggle light and dark mode">
+          <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
+          <span class="theme-toggle__label">Dark</span>
+        </button>
+      </div>
       <p id="typing" aria-live="polite"></p>
     </header>
 
     <section class="time-card" aria-labelledby="timeHeading">
       <div class="time-card__header">
-        <h2 id="timeHeading">Waktu Berjalan Sejak 4 Oktober 1974</h2>
-        <p>Kita rayakan setiap detik berharga yang telah menemani perjalananmu.</p>
+        <h2 id="timeHeading">Time Since October 4, 1974 (California, GMT-7)</h2>
+        <p>Here&apos;s how long this incredible journey has been unfolding on Pacific time.</p>
+        <p class="timezone-clock" aria-live="polite">Current time in California: <span id="timezoneClock">--:--:--</span></p>
       </div>
       <div class="time-grid" role="presentation">
         <article class="time-unit">
           <span class="time-number" id="years">0</span>
-          <span class="time-label">Tahun</span>
+          <span class="time-label">Years</span>
         </article>
         <article class="time-unit">
           <span class="time-number" id="months">0</span>
-          <span class="time-label">Bulan</span>
+          <span class="time-label">Months</span>
         </article>
         <article class="time-unit">
           <span class="time-number" id="days">0</span>
-          <span class="time-label">Hari</span>
+          <span class="time-label">Days</span>
         </article>
         <article class="time-unit">
           <span class="time-number" id="hours">0</span>
-          <span class="time-label">Jam</span>
+          <span class="time-label">Hours</span>
         </article>
         <article class="time-unit">
           <span class="time-number" id="minutes">0</span>
-          <span class="time-label">Menit</span>
+          <span class="time-label">Minutes</span>
         </article>
         <article class="time-unit">
           <span class="time-number" id="seconds">0</span>
-          <span class="time-label">Detik</span>
+          <span class="time-label">Seconds</span>
         </article>
       </div>
     </section>
 
     <section class="celebration" aria-live="polite">
-      <p class="celebration__message">🎉 Selamat Ulang Tahun! Semoga segala doa, asa, dan rencana yang kamu simpan rapi perlahan satu per satu jadi kenyataan.</p>
-      <p class="celebration__note">Gulir terus ke bawah, karena cerita indahmu masih panjang dan siap diisi dengan foto serta kenangan baru.</p>
+      <p class="celebration__message">🎉 Happy Birthday! May every dream you&apos;ve carefully kept come to life one by one.</p>
+      <p class="celebration__note">Keep scrolling—your story has so many more chapters waiting to be filled with photos and memories.</p>
     </section>
 
     <section class="photo-section" aria-labelledby="galleryHeading">
       <div class="photo-section__intro">
-        <h2 id="galleryHeading">Galeri Kenangan (Placeholder)</h2>
-        <p>Tempat foto-foto spesialmu akan tinggal. Untuk sekarang, geser ke kanan atau kiri untuk melihat placeholder-nya.</p>
+        <h2 id="galleryHeading">Memory Gallery (Placeholder)</h2>
+        <p>This is where the highlight reel will live. For now, swipe left or right to preview the placeholders.</p>
       </div>
-      <div class="photo-slider" aria-label="Galeri foto yang dapat digeser">
-        <button class="slider-nav prev" aria-label="Foto sebelumnya" type="button">‹</button>
+      <div class="photo-slider" aria-label="Swipeable photo gallery">
+        <button class="slider-nav prev" aria-label="Previous photo" type="button">‹</button>
         <div class="slides-window">
           <div class="slides">
             <figure class="slide">
-              <div class="photo-placeholder">Foto pertama akan tampil di sini.</div>
-              <figcaption>Siapkan cerita terbaik untuk momen istimewa ini.</figcaption>
+              <div class="photo-placeholder">The first snapshot will appear here.</div>
+              <figcaption>Start planning the story behind this standout moment.</figcaption>
             </figure>
             <figure class="slide">
-              <div class="photo-placeholder">Tempat untuk potret kebersamaan.</div>
-              <figcaption>Tinggalkan jejak kebersamaan yang hangat.</figcaption>
+              <div class="photo-placeholder">A space reserved for togetherness.</div>
+              <figcaption>Capture the warmth of being surrounded by your favorite people.</figcaption>
             </figure>
             <figure class="slide">
-              <div class="photo-placeholder">Kenangan spesial menyusul segera.</div>
-              <figcaption>Kenangan baru siap kamu simpan di sini.</figcaption>
+              <div class="photo-placeholder">Special memories coming soon.</div>
+              <figcaption>New adventures are already lining up for a place in this frame.</figcaption>
             </figure>
             <figure class="slide">
-              <div class="photo-placeholder">Ruangan kosong untuk kejutan.</div>
-              <figcaption>Mungkin foto kejutan dari sahabat terdekatmu?</figcaption>
+              <div class="photo-placeholder">Room reserved for a surprise.</div>
+              <figcaption>Maybe a secret photo from your closest crew?</figcaption>
             </figure>
           </div>
         </div>
-        <button class="slider-nav next" aria-label="Foto berikutnya" type="button">›</button>
+        <button class="slider-nav next" aria-label="Next photo" type="button">›</button>
       </div>
     </section>
 
     <footer class="closing-note">
-      <p>Terima kasih sudah menjadi bagian dari perjalanan panjang nan bermakna ini. Mari lanjutkan perayaannya dengan senyum lebar dan hati ringan.</p>
+      <p>Thank you for making every mile of this meaningful journey unforgettable. Let&apos;s keep the celebration going with bright smiles and an open heart.</p>
     </footer>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -1,11 +1,31 @@
 :root {
-  --bg-gradient: radial-gradient(circle at top, #141b2d 0%, #05070e 65%, #020204 100%);
+  color-scheme: dark;
+  --bg-color: #05070e;
+  --text-color: #f2f4ff;
+  --text-muted: rgba(242, 244, 255, 0.72);
   --accent: #ffcc00;
   --accent-strong: #ff5f6d;
-  --text-light: #f2f4ff;
-  --panel: rgba(12, 18, 34, 0.85);
-  --panel-border: rgba(255, 255, 255, 0.2);
-  --shadow: 0 20px 45px rgba(0, 0, 0, 0.5);
+  --panel: rgba(12, 18, 34, 0.82);
+  --panel-border: rgba(255, 255, 255, 0.16);
+  --shadow: 0 20px 45px rgba(0, 0, 0, 0.45);
+  --time-unit-bg: linear-gradient(160deg, rgba(255, 204, 0, 0.2) 0%, rgba(255, 95, 109, 0.25) 100%);
+  --time-card-bg: rgba(10, 15, 29, 0.92);
+  --placeholder-bg: repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.08) 0px, rgba(255, 255, 255, 0.08) 14px, rgba(255, 255, 255, 0.02) 14px, rgba(255, 255, 255, 0.02) 28px);
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --bg-color: #f4f7ff;
+  --text-color: #1f2341;
+  --text-muted: rgba(31, 35, 65, 0.72);
+  --accent: #ff7b00;
+  --accent-strong: #e84393;
+  --panel: rgba(255, 255, 255, 0.92);
+  --panel-border: rgba(25, 45, 92, 0.12);
+  --shadow: 0 24px 40px rgba(18, 32, 64, 0.16);
+  --time-unit-bg: linear-gradient(160deg, rgba(255, 123, 0, 0.12) 0%, rgba(232, 67, 147, 0.18) 100%);
+  --time-card-bg: rgba(255, 255, 255, 0.9);
+  --placeholder-bg: repeating-linear-gradient(135deg, rgba(31, 35, 65, 0.08) 0px, rgba(31, 35, 65, 0.08) 14px, rgba(31, 35, 65, 0.02) 14px, rgba(31, 35, 65, 0.02) 28px);
 }
 
 * {
@@ -17,25 +37,12 @@ body {
   font-family: "Orbitron", "Montserrat", system-ui, sans-serif;
   min-height: 100vh;
   display: block;
-  background: var(--bg-gradient);
-  color: var(--text-light);
+  background: var(--bg-color);
+  color: var(--text-color);
   overflow-x: hidden;
   overflow-y: auto;
   position: relative;
   padding: clamp(3rem, 4vw, 5rem) 0;
-}
-
-body::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  background-image: url("https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=60");
-  background-size: cover;
-  background-position: center;
-  mix-blend-mode: screen;
-  opacity: 0.18;
-  pointer-events: none;
-  z-index: -1;
 }
 
 #confetti {
@@ -62,10 +69,20 @@ body::before {
   gap: clamp(2rem, 4vw, 3rem);
 }
 
+.header-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
 header {
   text-align: center;
   display: grid;
   gap: 0.75rem;
+  justify-items: center;
 }
 
 h1 {
@@ -83,11 +100,56 @@ h1 {
   letter-spacing: 0.15em;
 }
 
+.timezone-clock {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  background: transparent;
+  color: var(--text-color);
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+:root[data-theme="light"] .theme-toggle:hover,
+:root[data-theme="light"] .theme-toggle:focus-visible {
+  background: rgba(31, 35, 65, 0.06);
+  border-color: rgba(31, 35, 65, 0.18);
+}
+
+.theme-toggle__icon {
+  font-size: 1.2rem;
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
 .time-card {
   padding: clamp(1.75rem, 3vw, 2.5rem);
   border-radius: 24px;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  background: rgba(10, 15, 29, 0.9);
+  border: 1px solid var(--panel-border);
+  background: var(--time-card-bg);
   display: grid;
   gap: 1.75rem;
 }
@@ -114,8 +176,8 @@ h1 {
   gap: 0.35rem;
   padding: 1rem 0.75rem;
   border-radius: 20px;
-  background: linear-gradient(160deg, rgba(255, 204, 0, 0.2) 0%, rgba(255, 95, 109, 0.25) 100%);
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: var(--time-unit-bg);
+  border: 1px solid var(--panel-border);
   box-shadow: inset 0 0 18px rgba(255, 204, 0, 0.12);
 }
 
@@ -129,7 +191,7 @@ h1 {
   font-size: 0.85rem;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-muted);
 }
 
 .celebration {
@@ -164,8 +226,8 @@ h1 {
 .slides-window {
   overflow: hidden;
   border-radius: 22px;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.45);
+  border: 1px solid var(--panel-border);
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.25);
 }
 
 .slides {
@@ -178,15 +240,15 @@ h1 {
   max-width: min(620px, 72vw);
   display: flex;
   flex-direction: column;
-  background: rgba(3, 8, 19, 0.9);
+  background: var(--panel);
 }
 
 .photo-placeholder {
   display: grid;
   place-items: center;
   height: clamp(240px, 45vw, 360px);
-  background: repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.08) 0px, rgba(255, 255, 255, 0.08) 14px, rgba(255, 255, 255, 0.02) 14px, rgba(255, 255, 255, 0.02) 28px);
-  color: rgba(255, 255, 255, 0.8);
+  background: var(--placeholder-bg);
+  color: var(--text-muted);
   font-size: 1.05rem;
   text-align: center;
   padding: 1.5rem;
@@ -198,39 +260,39 @@ h1 {
   padding: 1rem 1.5rem;
   font-size: 0.95rem;
   letter-spacing: 0.05em;
-  background: rgba(255, 255, 255, 0.04);
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text-muted);
 }
 
 .slider-nav {
-  width: 52px;
-  height: 52px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.12);
-  border: 1px solid rgba(255, 255, 255, 0.35);
-  color: var(--accent);
-  font-size: 2rem;
-  font-weight: 700;
+  width: 48px;
+  height: 48px;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  background: transparent;
+  color: var(--text-color);
+  display: grid;
+  place-items: center;
+  font-size: 1.8rem;
   cursor: pointer;
-  transition: transform 0.2s ease, background 0.2s ease;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .slider-nav:hover,
 .slider-nav:focus-visible {
-  background: rgba(255, 204, 0, 0.2);
-  transform: scale(1.08);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25);
 }
 
 .slider-nav:focus-visible {
-  outline: 3px solid rgba(255, 204, 0, 0.45);
-  outline-offset: 3px;
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
 }
 
 .closing-note {
   text-align: center;
-  font-size: 0.95rem;
-  line-height: 1.8;
-  color: rgba(255, 255, 255, 0.7);
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--text-muted);
 }
 
 .balloon {


### PR DESCRIPTION
## Summary
- translate the landing page copy to English and highlight the California (GMT-7) timeline with a live clock
- implement a persistent light/dark theme toggle and restyle the layout for a solid background treatment
- update the timer logic to operate in GMT-7 and localize number formatting for the new copy

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e035ff6e6083298af72a6ca3909ceb