### PR TITLE
Convert gallery into auto carousel and improve aim rotation

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,43 +94,45 @@
         <button class="slider-control slider-control--prev" type="button" aria-label="Foto sebelumnya">‹</button>
 
         <div class="slides-window">
-          <div class="slides">
-            <figure class="slide" data-reveal>
+          <div class="slides" role="list">
+            <figure class="slide" id="memory-slide-1" data-reveal role="listitem">
               <img class="slide__image" src="pictures/foto1.jpg" alt="Andy smiling in a blue blazer with palm trees behind him." loading="lazy" />
               <figcaption>The ocean breeze, your easy smile, and the way every horizon feels calmer with you in it.</figcaption>
             </figure>
 
-            <figure class="slide" data-reveal>
+            <figure class="slide" id="memory-slide-2" data-reveal role="listitem">
               <img class="slide__image" src="pictures/foto2.jpg" alt="Andy smiling inside a cozy lounge." loading="lazy" />
               <figcaption>Quiet in-between moments where the world slows down and we get to simply exist together.</figcaption>
             </figure>
 
-            <figure class="slide" data-reveal>
+            <figure class="slide" id="memory-slide-3" data-reveal role="listitem">
               <img class="slide__image" src="pictures/foto3.jpg" alt="Andy and his partner smiling at Borobudur Temple." loading="lazy" />
               <figcaption>Exploring Borobudur with you felt like unlocking a brand-new chapter in our story.</figcaption>
             </figure>
 
-            <figure class="slide" data-reveal>
+            <figure class="slide" id="memory-slide-4" data-reveal role="listitem">
               <img class="slide__image" src="pictures/foto4.jpg" alt="Andy resting on a pillow with a gentle smile." loading="lazy" />
               <figcaption>Even your calmest moments are filled with warmth—it’s my favorite comfort.</figcaption>
             </figure>
 
-            <figure class="slide" data-reveal>
+            <figure class="slide" id="memory-slide-5" data-reveal role="listitem">
               <img class="slide__image" src="pictures/foto5.jpg" alt="Andy and his partner smiling during dinner together." loading="lazy" />
               <figcaption>Dinner dates and shared laughter—proof that ordinary days become magic when you’re beside me.</figcaption>
             </figure>
 
-            <figure class="slide" data-reveal>
+            <figure class="slide" id="memory-slide-6" data-reveal role="listitem">
               <img class="slide__image" src="pictures/foto6.jpg" alt="Andy working on a tablet beside a Yakitori Night sign." loading="lazy" />
               <figcaption>You balance focus and fun so effortlessly—always ready with a grin and a clever idea.</figcaption>
             </figure>
 
-            <figure class="slide" data-reveal>
+            <figure class="slide" id="memory-slide-7" data-reveal role="listitem">
               <img class="slide__image" src="pictures/foto7.jpg" alt="Andy wearing a sunhat and smiling at an ancient temple." loading="lazy" />
               <figcaption>Your playful spirit keeps every adventure bright, no matter how far from home we roam.</figcaption>
             </figure>
           </div>
         </div>
+
+        <div class="slider-dots" role="tablist" aria-label="Navigasi galeri kenangan"></div>
 
         <button class="slider-control slider-control--next" type="button" aria-label="Foto berikutnya">›</button>
       </div>

--- a/style.css
+++ b/style.css
@@ -183,37 +183,42 @@ body {
 
 .photo-slider {
   position: relative;
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: center;
+  gap: clamp(0.75rem, 3vw, 1.5rem);
 }
 
 .slides-window {
-  overflow: visible;
+  overflow: hidden;
   position: relative;
-  padding: 3.5rem 0;
+  border-radius: 24px;
+  box-shadow: var(--shadow-xl);
+  background: var(--bg-panel);
+  width: min(720px, 88vw);
 }
 
 .slides {
-  position: relative;
   display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: clamp(260px, 45vw, 420px);
-  perspective: 1400px;
+  transition: transform 0.6s ease;
+  transform: translate3d(0, 0, 0);
 }
 
 .slide {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: clamp(220px, 60vw, 420px);
-  transform: translate(-50%, -50%);
-  border-radius: 20px;
+  flex: 0 0 100%;
+  display: grid;
+  grid-template-rows: minmax(0, auto) auto;
+  background: rgba(4, 6, 13, 0.55);
+  border-radius: 24px;
   overflow: hidden;
-  box-shadow: var(--shadow-xl);
-  background: rgba(0, 0, 0, 0.35);
-  transition: all 0.5s ease;
+  opacity: 0.65;
+  transform: scale(0.96);
+  transition: opacity 0.45s ease, transform 0.45s ease;
+}
+
+.slide.is-active {
+  opacity: 1;
+  transform: scale(1);
 }
 
 .slide__image {
@@ -221,19 +226,15 @@ body {
   height: auto;
   aspect-ratio: 4 / 3;
   object-fit: cover;
-  border-radius: 20px 20px 0 0;
   display: block;
-  margin: 0 auto;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
 }
 
 .slide figcaption {
-  padding: 1rem 1.4rem;
+  padding: clamp(1rem, 3vw, 1.4rem);
   background: rgba(4, 6, 13, 0.75);
   color: var(--text-soft);
-  font-size: 0.95rem;
-  backdrop-filter: blur(12px);
-  border-radius: 0 0 20px 20px;
+  font-size: clamp(0.92rem, 2.5vw, 1.02rem);
+  line-height: 1.6;
 }
 
 .slider-control {
@@ -241,17 +242,71 @@ body {
   border: none;
   color: var(--text);
   border-radius: 50%;
-  width: 46px;
-  height: 46px;
-  font-size: 1.6rem;
+  width: 48px;
+  height: 48px;
+  font-size: 1.5rem;
   cursor: pointer;
   box-shadow: var(--shadow-lg);
-  transition: 0.3s;
+  transition: transform 0.3s ease, background 0.3s ease;
   z-index: 5;
 }
 
 .slider-control:hover {
   background: rgba(12, 18, 34, 0.75);
+  transform: scale(1.05);
+}
+
+.slider-dots {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.6rem;
+  margin-top: 1.1rem;
+}
+
+.slider-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+  cursor: pointer;
+  transition: transform 0.3s ease, background 0.3s ease;
+}
+
+.slider-dot.is-active {
+  background: var(--accent);
+  transform: scale(1.15);
+  box-shadow: 0 0 12px rgba(255, 200, 87, 0.6);
+}
+
+.slider-dot:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+@media (max-width: 640px) {
+  .photo-slider {
+    grid-template-columns: 1fr;
+  }
+
+  .slider-control {
+    justify-self: center;
+  }
+
+  .slider-control--prev {
+    order: -1;
+  }
+
+  .slider-control--next {
+    order: 1;
+  }
+
+  .slides-window {
+    width: min(92vw, 520px);
+  }
 }
 
 /* =========================
@@ -332,6 +387,7 @@ body {
   height: 100%;
   transform-style: preserve-3d;
   pointer-events: none;
+  transition: transform 0.25s ease-out;
 }
 
 model-viewer {


### PR DESCRIPTION
## Summary
- convert the memory gallery slider into an auto-playing carousel with navigation dots and accessibility improvements
- refresh the gallery styling to match the new carousel layout across screen sizes
- rotate the pistol and flashlight pivots to follow the cursor with smooth reset when leaving the page

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e0da0cc7dc83298ae85b316df99e33